### PR TITLE
Add CheckHacks to hall of shame

### DIFF
--- a/HALL_OF_SHAME.md
+++ b/HALL_OF_SHAME.md
@@ -25,3 +25,4 @@ Here is a list of plugins that used these exploits:
 |----------------------------------------------------------------------|----------------------------------------|-----------------------------|
 | [EXMNT](https://github.com/MidnightTale/EXMNT)                       | https://github.com/MidnightTale/EXMNT  | Translation key (✔)         |
 | [TotemGuard](https://github.com/Bram1903/TotemGuard/releases/latest) | https://github.com/Bram1903/TotemGuard | Translation key (✔)         |
+| [CheckHacks](https://www.spigotmc.org/resources/checkhacks.133154/)  | Closed-source                          | Translation key (✔)         |


### PR DESCRIPTION
The plugin [CheckHacks](https://www.spigotmc.org/resources/checkhacks.133154/) uses the sign translation vulnerability to detect mods by using translation and keybind resolution. It does not have public source code linked on the Spigot page.