### PR TITLE
Add uneasyvanilla.com to HALL_OF_SHAME

### DIFF
--- a/HALL_OF_SHAME.md
+++ b/HALL_OF_SHAME.md
@@ -22,6 +22,7 @@ Here is a list of servers that used these exploits:
 | pvphub.me           | https://store.pvphub.me/      | Translation key (✔)                                             |
 | unstableevents.net  | -                             | Translation key (✔)                                             |
 | playunstable.net    | https://unstableanalysis.com/ | Translation key (✔)                                             |
+| uneasyvanilla.com   | https://uneasyvanilla.com/    | Translation key (✔)                                             |
 
 ## Plugins
 Here is a list of plugins that used these exploits:


### PR DESCRIPTION
uneasyvanilla.com has been caught using translation keys to detect people's mods

specifically:
`key.meteor-client.open-gui`
`key.killaura`
`key.playeresp.open_config`
`x13.mod.xray`
`keybind.invmove.toggleMove`
`key.baritone.pathToggle`
`key.seedcrackerx.open_menu`
`key.meteor-client.open-commands`
`key.autoattack.afkAttack`
`key.xray.toggle`
`key.freecam.toggle`
`key.flymod.toggle`
`key.ecs.swap`
`key.seedcracker.open_menu`
`key.wurst.zoom`
`key.autoswitch.toggle`
`xray.config.open`
`key.zergatul.freecam.toggle`
`key.autotools.get_tool`
`key.autototem.toggle`
`category.antitoolbreak`
`liquidbounce.generic.enabled`
`key.chestesp.toggle`
`keybinding.enable_xray`
`key.stepup.toggle`
`key.autofish.open_gui`
`key.desc.mace_attack_assistance`
