### PR TITLE
Update Minecraft version constraint in fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,7 +22,7 @@
   ],
   "depends": {
     "java": ">=21",
-    "minecraft": ${minecraft_versions},
+    "minecraft": "~${minecraft_versions}",
     "fabricloader": "*",
     "fabric-api": ">=${minimal_fabric_api_version}"
   },


### PR DESCRIPTION
This makes it so the Fabric Loader does not complain in startup about hard dependency requirement being violated when running 26.1.1 or 26.1.2.