### PR TITLE
Add cntier.club to HALL_OF_SHAME.md

### DIFF
--- a/HALL_OF_SHAME.md
+++ b/HALL_OF_SHAME.md
@@ -27,6 +27,7 @@ Here is a list of servers that used these exploits:
 | pvpparadise.net      | -                             | Translation key (✔)                                             |
 | play.dgnetwork.in    | https://dgnetwork.in/         | Translation key (✔)                                             |
 | cutesmp.net          | https://store.cutesmp.net/    | Translation key (✔)                                             |
+| cntier.club          | -                             | Translation key (✔)                                             |
 
 ## Plugins
 Here is a list of plugins that used these exploits:


### PR DESCRIPTION
cntier.club is using translation keys to detect and block your client mods

they even blocked `NoChatReports`, wtf

**translation key dump:**
```
key.meteor-client.open-gui
tweakeroo.config.tab.tweaks
tweakermore.hotkeys.category.main
itemscroller.config.tab.generic
malilib.on
litematica.gui.button.config
key.freecam.toggle
inventoryprofiles.gui.config.title
gui.protocol_version_field.name
cracker.enabled
nametagtweaks.key.open_settings
nametag-tweaks.nametag-tweaks
key.categories.healthindicators
key.name_visibility.toggleNames
jm.advanced.automappoll
minimap.ui.north
key.category.accurateblockplacement.category
key.SwapInventory.QAQ
modmenu.nameTranslation.jade
config.invmove.title
key.category.autoclicker.keybinding-title
xray.mod_name
key.category.cheatutils.common
neat.keybind.toggle
key.nochatreports.cmd
config.bridgingmod.title
shouldersurfing.configuration.camera
freelook.key.menu
key.stepup.toggle
key.inventoryessentials.bulk_drop
key.autotools.category
key.autoswitch.toggle
key.category.chestesp.chestesp
key.crawl
text.autoconfig.elytrapitch.title
config.do_a_barrel_roll.title
key.autofish.open_gui
```